### PR TITLE
Fix cyber_monitor signal handling

### DIFF
--- a/cyber/tools/cyber_monitor/main.cc
+++ b/cyber/tools/cyber_monitor/main.cc
@@ -26,7 +26,10 @@
 
 namespace {
 void SigResizeHandle(int) { Screen::Instance()->Resize(); }
-void SigCtrlCHandle(int) { Screen::Instance()->Stop(); }
+void SigCtrlCHandle(int sig) {
+  Screen::Instance()->Stop();
+  apollo::cyber::OnShutdown(sig);
+}
 
 void printHelp(const char *cmd_name) {
   std::cout << "Usage:\n"


### PR DESCRIPTION
## Summary
- ensure that cyber monitor properly shuts down when receiving SIGINT

## Testing
- `python3 -m cpplint cyber/tools/cyber_monitor/main.cc` *(fails: No module named cpplint)*
- `bazel test //cyber/tools/cyber_monitor:cpplint` *(fails due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685f53abdb108333b60a57e8fbd6c93f