### PR TITLE
Optimize cpu usage in cyber_recorder

### DIFF
--- a/cyber/tools/cyber_recorder/main.cc
+++ b/cyber/tools/cyber_recorder/main.cc
@@ -516,9 +516,7 @@ int main(int argc, char** argv) {
     }
     bool record_result = recorder->Start();
     if (record_result) {
-      while (!::apollo::cyber::IsShutdown()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
+      apollo::cyber::WaitForShutdown();
       record_result = recorder->Stop();
     }
     return record_result ? 0 : -1;

--- a/cyber/tools/cyber_recorder/player/player.cc
+++ b/cyber/tools/cyber_recorder/player/player.cc
@@ -24,7 +24,7 @@ namespace apollo {
 namespace cyber {
 namespace record {
 
-const uint64_t Player::kSleepIntervalMiliSec = 100;
+const uint64_t Player::kSleepIntervalMiliSec = 200;
 
 Player::Player(const PlayParam& play_param, const NodePtr& node,
                const bool preload_fill_buffer_mode)

--- a/cyber/tools/cyber_recorder/player/player.h
+++ b/cyber/tools/cyber_recorder/player/player.h
@@ -90,6 +90,7 @@ class Player {
   std::shared_ptr<std::thread> term_thread_ = nullptr;
   // add nohup_play_th_ to allow background play record
   std::shared_ptr<std::thread> nohup_play_th_ = nullptr;
+  // Sleep interval for internal status loops in milliseconds.
   static const uint64_t kSleepIntervalMiliSec;
 };
 

--- a/cyber/tools/cyber_recorder/recorder.cc
+++ b/cyber/tools/cyber_recorder/recorder.cc
@@ -17,6 +17,7 @@
 #include "cyber/tools/cyber_recorder/recorder.h"
 
 #include <algorithm>
+#include <chrono>
 
 #include "cyber/record/header_builder.h"
 
@@ -110,6 +111,7 @@ bool Recorder::Stop() {
     return false;
   }
   is_stopping_ = true;
+  progress_cv_.notify_all();
   if (!FreeReadersImpl()) {
     AERROR << " _free_readers error.";
     return false;
@@ -276,17 +278,36 @@ void Recorder::ReaderCallback(const std::shared_ptr<RawMessage>& message,
     return;
   }
 
-  message_count_++;
+  {
+    std::lock_guard<std::mutex> lk(progress_mutex_);
+    message_count_++;
+  }
+  progress_cv_.notify_one();
 }
 
 void Recorder::ShowProgress() {
+  uint64_t last_count = 0;
+  auto last_print = std::chrono::steady_clock::now();
   while (is_started_ && !is_stopping_) {
-    std::cout << "\r[RUNNING]  Record Time: " << std::setprecision(3)
-              << message_time_ / 1000000000
-              << "    Progress: " << channel_reader_map_.size() << " channels, "
-              << message_count_ << " messages";
-    std::cout.flush();
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::unique_lock<std::mutex> lk(progress_mutex_);
+    progress_cv_.wait_for(
+        lk, std::chrono::seconds(1), [this, &last_count, &last_print] {
+          return message_count_ != last_count ||
+                 std::chrono::steady_clock::now() - last_print >=
+                     std::chrono::seconds(1) ||
+                 is_stopping_;
+        });
+    auto now = std::chrono::steady_clock::now();
+    if (message_count_ != last_count ||
+        now - last_print >= std::chrono::seconds(1)) {
+      std::cout << "\r[RUNNING]  Record Time: " << std::setprecision(3)
+                << message_time_ / 1000000000
+                << "    Progress: " << channel_reader_map_.size()
+                << " channels, " << message_count_ << " messages";
+      std::cout.flush();
+      last_count = message_count_;
+      last_print = now;
+    }
   }
   std::cout << std::endl;
 }

--- a/cyber/tools/cyber_recorder/recorder.h
+++ b/cyber/tools/cyber_recorder/recorder.h
@@ -17,6 +17,7 @@
 #ifndef CYBER_TOOLS_CYBER_RECORDER_RECORDER_H_
 #define CYBER_TOOLS_CYBER_RECORDER_RECORDER_H_
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <regex>
@@ -65,6 +66,8 @@ class Recorder : public std::enable_shared_from_this<Recorder> {
   std::shared_ptr<Node> node_ = nullptr;
   std::shared_ptr<RecordWriter> writer_ = nullptr;
   std::shared_ptr<std::thread> display_thread_ = nullptr;
+  std::mutex progress_mutex_;
+  std::condition_variable progress_cv_;
   Connection<const ChangeMsg&> change_conn_;
   std::string output_;
   bool all_channels_ = true;


### PR DESCRIPTION
## Summary
- throttle progress update in `Recorder::ShowProgress`
- reduce busy waiting by using `WaitForShutdown()`
- lower status update frequency for `Player`
- document player loop interval
- wake progress thread only when new messages arrive to minimize idle spinning

## Testing
- `bash scripts/apollo_format.sh -c cyber/tools/cyber_recorder/recorder.cc`

------
https://chatgpt.com/codex/tasks/task_e_6861e99f5dac8333a194ed71b68fea37