### PR TITLE
Add trigger for stop or manual mode

### DIFF
--- a/modules/data/tools/smart_recorder/BUILD
+++ b/modules/data/tools/smart_recorder/BUILD
@@ -23,6 +23,7 @@ apollo_cc_library(
         "realtime_record_processor.cc",
         "record_processor.cc",
         "regular_interval_trigger.cc",
+        "stop_manual_trigger.cc",
         "small_topics_trigger.cc",
         "smart_recorder_gflags.cc",
         "swerve_trigger.cc",
@@ -42,6 +43,7 @@ apollo_cc_library(
         "small_topics_trigger.h",
         "smart_recorder_gflags.h",
         "swerve_trigger.h",
+        "stop_manual_trigger.h",
         "trigger_base.h",
     ],
     deps = [

--- a/modules/data/tools/smart_recorder/conf/smart_recorder_config.pb.txt
+++ b/modules/data/tools/smart_recorder/conf/smart_recorder_config.pb.txt
@@ -62,3 +62,11 @@ triggers {
   forward_time: 30.0
   description: "triggered when bumper was pressed by car crashed happened"
 }
+
+triggers {
+  trigger_name: "StopManualTrigger"
+  enabled: true
+  backward_time: 45.0
+  forward_time: 0.0
+  description: "triggered when stop for 5s or switch to manual mode"
+}

--- a/modules/data/tools/smart_recorder/record_processor.cc
+++ b/modules/data/tools/smart_recorder/record_processor.cc
@@ -27,6 +27,7 @@
 #include "modules/data/tools/smart_recorder/regular_interval_trigger.h"
 #include "modules/data/tools/smart_recorder/small_topics_trigger.h"
 #include "modules/data/tools/smart_recorder/swerve_trigger.h"
+#include "modules/data/tools/smart_recorder/stop_manual_trigger.h"
 
 namespace apollo {
 namespace data {
@@ -83,6 +84,7 @@ bool RecordProcessor::InitTriggers(const SmartRecordTrigger& trigger_conf) {
   triggers_.push_back(std::unique_ptr<TriggerBase>(new SmallTopicsTrigger));
   triggers_.push_back(std::unique_ptr<TriggerBase>(new RegularIntervalTrigger));
   triggers_.push_back(std::unique_ptr<TriggerBase>(new SwerveTrigger));
+  triggers_.push_back(std::unique_ptr<TriggerBase>(new StopManualTrigger));
   triggers_.push_back(std::unique_ptr<TriggerBase>(new BumperCrashTrigger));
   for (const auto& trigger : triggers_) {
     if (!trigger->Init(trigger_conf)) {

--- a/modules/data/tools/smart_recorder/stop_manual_trigger.cc
+++ b/modules/data/tools/smart_recorder/stop_manual_trigger.cc
@@ -1,0 +1,47 @@
+#include "modules/data/tools/smart_recorder/stop_manual_trigger.h"
+
+#include "cyber/common/log.h"
+#include "modules/common/adapters/adapter_gflags.h"
+
+namespace apollo {
+namespace data {
+
+using apollo::canbus::Chassis;
+
+StopManualTrigger::StopManualTrigger() { trigger_name_ = "StopManualTrigger"; }
+
+void StopManualTrigger::Pull(const cyber::record::RecordMessage& msg) {
+  if (!trigger_obj_ || !trigger_obj_->enabled()) {
+    return;
+  }
+  if (msg.channel_name == FLAGS_chassis_topic) {
+    Chassis chassis_msg;
+    chassis_msg.ParseFromString(msg.content);
+    // Manual driving switch
+    if (last_driving_mode_ != chassis_msg.driving_mode() &&
+        chassis_msg.driving_mode() == Chassis::COMPLETE_MANUAL) {
+      AINFO << "manual mode trigger is pulled: " << msg.time;
+      TriggerIt(msg.time);
+    }
+    last_driving_mode_ = chassis_msg.driving_mode();
+
+    // Check stop duration
+    const float speed = chassis_msg.speed_mps();
+    if (fabs(speed) < 0.1) {
+      if (stop_start_time_ == 0) {
+        stop_start_time_ = msg.time;
+        stop_triggered_ = false;
+      } else if (!stop_triggered_ &&
+                 msg.time - stop_start_time_ >= SecondsToNanoSeconds(5.0)) {
+        AINFO << "stop 5s trigger is pulled: " << msg.time;
+        TriggerIt(msg.time);
+        stop_triggered_ = true;
+      }
+    } else {
+      stop_start_time_ = 0;
+    }
+  }
+}
+
+}  // namespace data
+}  // namespace apollo

--- a/modules/data/tools/smart_recorder/stop_manual_trigger.h
+++ b/modules/data/tools/smart_recorder/stop_manual_trigger.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "modules/common_msgs/chassis_msgs/chassis.pb.h"
+#include "modules/data/tools/smart_recorder/proto/smart_recorder_triggers.pb.h"
+#include "modules/data/tools/smart_recorder/trigger_base.h"
+
+namespace apollo {
+namespace data {
+
+// Trigger when vehicle stops for a while or switches to manual driving
+class StopManualTrigger : public TriggerBase {
+ public:
+  StopManualTrigger();
+
+  void Pull(const cyber::record::RecordMessage& msg) override;
+  bool ShouldRestore(const cyber::record::RecordMessage& msg) const override { return false; };
+
+  virtual ~StopManualTrigger() = default;
+
+ private:
+  apollo::canbus::Chassis::DrivingMode last_driving_mode_ =
+      apollo::canbus::Chassis::COMPLETE_MANUAL;
+  uint64_t stop_start_time_ = 0UL;
+  bool stop_triggered_ = false;
+};
+
+}  // namespace data
+}  // namespace apollo


### PR DESCRIPTION
## Summary
- add `StopManualTrigger` which activates when the vehicle stops for 5 seconds or driver switches to manual control
- register trigger in `RecordProcessor`
- compile files in BUILD and enable the new trigger via config

## Testing
- `bazel build //modules/data/tools/smart_recorder:apollo_data_tools_smart_recorder` *(failed: network access needed)*
- `bash apollo.sh lint` *(failed: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_686b1144de848333a9cc2e05d1df6ed1